### PR TITLE
refactor: ViewModel 이 ObservableObject 를 채택하지 않고, @Observable 매크로를 사용하도록 개선

### DIFF
--- a/Projects/babyMoa/babyMoa/App/BabyMoaRoot/BabyMoaRootView.swift
+++ b/Projects/babyMoa/babyMoa/App/BabyMoaRoot/BabyMoaRootView.swift
@@ -34,11 +34,13 @@ struct BabyMoaRootView: View {
                     SignUpView(coordinator: coordinator)
                         .navigationBarBackButtonHidden()
                 case .growth:
-                    EmptyView()
+                    GrowthView()
+                        .navigationBarBackButtonHidden()
                 case .journey:
                     EmptyView()
                 case .privacyConsent:
-                    EmptyView()
+                    PrivacyConsentView(coordinator: coordinator)
+                        .navigationBarBackButtonHidden()
                 }
             }
         }

--- a/Projects/babyMoa/babyMoa/Views/Auth/BabyMoaStart/BabyMoaStartView.swift
+++ b/Projects/babyMoa/babyMoa/Views/Auth/BabyMoaStart/BabyMoaStartView.swift
@@ -9,10 +9,10 @@ import SwiftUI
 
 struct BabyMoaStartView: View {
     
-    @StateObject var viewModel: BabyMoaStartViewModel
+    @State var viewModel: BabyMoaStartViewModel
     
     init(coordinator: BabyMoaCoordinator) {
-        _viewModel = StateObject(wrappedValue: BabyMoaStartViewModel(coordinator: coordinator))
+        viewModel = BabyMoaStartViewModel(coordinator: coordinator)
     }
     
     var body: some View {

--- a/Projects/babyMoa/babyMoa/Views/Auth/BabyMoaStart/BabyMoaStartViewModel.swift
+++ b/Projects/babyMoa/babyMoa/Views/Auth/BabyMoaStart/BabyMoaStartViewModel.swift
@@ -7,8 +7,9 @@
 
 import SwiftUI
 
-class BabyMoaStartViewModel: ObservableObject {
-    @ObservedObject var coordinator: BabyMoaCoordinator
+@Observable
+class BabyMoaStartViewModel {
+    var coordinator: BabyMoaCoordinator
     
     init(coordinator: BabyMoaCoordinator) {
         self.coordinator = coordinator

--- a/Projects/babyMoa/babyMoa/Views/Auth/SignUp/SignUpView.swift
+++ b/Projects/babyMoa/babyMoa/Views/Auth/SignUp/SignUpView.swift
@@ -9,10 +9,10 @@ import AuthenticationServices
 import SwiftUI
 
 struct SignUpView: View {
-    @StateObject var viewModel: SignUpViewModel
+    @State var viewModel: SignUpViewModel
     
     init(coordinator: BabyMoaCoordinator) {
-        _viewModel = StateObject(wrappedValue: SignUpViewModel(coordinator: coordinator))
+        viewModel = SignUpViewModel(coordinator: coordinator)
     }
     
     var body: some View {

--- a/Projects/babyMoa/babyMoa/Views/Auth/SignUp/SignUpViewModel.swift
+++ b/Projects/babyMoa/babyMoa/Views/Auth/SignUp/SignUpViewModel.swift
@@ -7,9 +7,10 @@
 import AuthenticationServices
 import SwiftUI
 
-final class SignUpViewModel: ObservableObject {
-    @ObservedObject var coordinator: BabyMoaCoordinator
-    @Published var termCheckList: [TermCheckItem]
+@Observable
+final class SignUpViewModel {
+    var coordinator: BabyMoaCoordinator
+    var termCheckList: [TermCheckItem]
     
     init(coordinator: BabyMoaCoordinator) {
         self.coordinator = coordinator

--- a/Projects/babyMoa/babyMoa/Views/Growth/GrowthView.swift
+++ b/Projects/babyMoa/babyMoa/Views/Growth/GrowthView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 struct GrowthView: View {
     // MARK: - State Properties
-
+    
     @State private var viewModel = GrowthViewModel()
     @State private var showBabySelection = false
     @State private var showAllMilestones = false


### PR DESCRIPTION
## ✨ What’s this PR?
ViewModel 이 ObservableObject 를 채택하지 않고, @Observable 매크로를 사용하도록 개선

---

### 🧶 주요 변경 내용 (Summary)
ViewModel 이 ObservableObject 를 채택하지 않고, @Observable 매크로를 사용하도록 개선

---