### PR TITLE
Refactoring : BabyMoa 앱 아키텍처 리팩토링 구조 상세 문서 추가 및 팀 공유용 정리

### DIFF
--- a/Projects/BabyMoa/babyMoa/App/BabyMoaCoordinator.swift
+++ b/Projects/BabyMoa/babyMoa/App/BabyMoaCoordinator.swift
@@ -35,8 +35,11 @@ class BabyMoaCoordinator: ObservableObject {
 
 enum CoordinatorPath: Hashable {
     case startBabyMoa
+    // Account and Auth View
     case privacyConsent
     case login
+    case accountDeleteConfirmView
+    // Growth View
     case mainTab
     case growth
     case allMilestones

--- a/Projects/BabyMoa/babyMoa/App/BabyMoaRoot/BabyMoaRootView.swift
+++ b/Projects/BabyMoa/babyMoa/App/BabyMoaRoot/BabyMoaRootView.swift
@@ -8,22 +8,20 @@
 import SwiftUI
 
 struct BabyMoaRootView: View {
-    @StateObject var coordinator = BabyMoaCoordinator()
-    @StateObject var viewModel = BabyMoaRootViewModel()
-    @StateObject var alertManager = AlertManager()
+    @StateObject private var coordinator = BabyMoaCoordinator()
+    @StateObject private var appState = AppState.shared
+    @StateObject private var alertManager = AlertManager()
     
     var body: some View {
         NavigationStack(path: $coordinator.paths) {
-            // isReady 상태에 따라 로딩 뷰 또는 컨텐츠 뷰를 표시
             Group {
-                if viewModel.isReady {
-                    VStack {
-                        // 초기 경로 설정이 완료된 후의 뷰 (현재는 비어 있음)
-                    }
-                    .navigationBarBackButtonHidden()
-                } else {
-                    // 앱 시작 시 데이터를 로드하는 동안 표시될 로딩 뷰
-                    ProgressView()
+                switch appState.sessionState {
+                case .signedIn:
+                    // 로그인 상태일 경우, AuthenticatedRootView를 통해 실제 메인 화면 또는 아기 추가 화면으로 분기
+                    AuthenticatedRootView(coordinator: coordinator)
+                case .signedOut:
+                    // 로그아웃 상태일 경우, BabyMoaStartView를 루트 뷰로 설정
+                    BabyMoaStartView(coordinator: coordinator)
                 }
             }
             .navigationDestination(for: CoordinatorPath.self) { path in
@@ -94,34 +92,27 @@ struct BabyMoaRootView: View {
                 case .newWeightAdd(let babyId):
                     WeightAddView(coordinator: coordinator, babyId: babyId)
                         .navigationBarBackButtonHidden()
+                    
+                case .accountDeleteConfirmView:
+                        AccountDeleteConfirmView(coordinator: coordinator)
+                        .navigationBarBackButtonHidden()
                 default:
                     EmptyView()
                 }
             }
         }
-        .onAppear {
-            // 뷰가 처음 나타날 때 초기 화면 경로를 결정하는 로직을 실행
-            if coordinator.paths.isEmpty {
-                Task {
-                    await viewModel.checkInitialScreen(coordinator: coordinator)
-                }
-            }
-        }
-        .onChange(of: coordinator.paths) { _, newValue in
-            // 로그인 성공 등으로 네비게이션 스택이 리셋되면(newValue.isEmpty) 초기 화면을 다시 결정합니다.
-            if newValue.isEmpty {
-                viewModel.isReady = false // 로딩 뷰를 다시 표시
-                Task {
-                    await viewModel.checkInitialScreen(coordinator: coordinator)
-                }
-            }
-        }
-        //MARK: - 경고창에 대해 사용하도로 해야 한다.
         .environmentObject(alertManager)
         .alert(alertManager.alertTitle, isPresented: $alertManager.showAlert) {
             Button("확인") { }
         } message: {
             Text(alertManager.alertMessage)
+        }
+        .onChange(of: appState.sessionState) { _, newState in
+            // 세션 상태가 로그아웃으로 변경되면, 네비게이션 스택을 모두 비워
+            // 깨끗한 상태에서 로그인/온보딩 플로우를 시작하도록 합니다.
+            if newState == .signedOut {
+                coordinator.paths.removeAll()
+            }
         }
     }
 }

--- a/Projects/BabyMoa/babyMoa/App/BabyMoaRoot/BabyMoaRootViewModel.swift
+++ b/Projects/BabyMoa/babyMoa/App/BabyMoaRoot/BabyMoaRootViewModel.swift
@@ -8,54 +8,9 @@
 import SwiftUI
 
 @MainActor
-
-//final class BabyMoaRootViewModel: ObservableObject {
-//    func isUserAuthorized() -> Bool {
-//        if UserToken.accessToken == "" {
-//            return false
-//        }
-//        return true
-//    }
-//}
-
-
 final class BabyMoaRootViewModel: ObservableObject {
-    /// 앱 로딩 및 초기 경로 설정이 완료되었는지 여부를 나타냅니다.
-    @Published var isReady = false
+    // 이 ViewModel의 역할은 AppState와 BabyMoaRootView 리팩토링으로 인해 축소되었습니다.
+    // 향후 앱의 전역적인 뷰 로직이 필요할 경우 여기에 추가할 수 있습니다.
     
-    private let babyMoaService: BabyMoaServicable
-    
-    init(babyMoaService: BabyMoaServicable = BabyMoaService.shared) {
-        self.babyMoaService = babyMoaService
-    }
-    
-    /// 앱 시작 시 사용자의 상태(로그인, 아기 등록 여부)를 확인하여 초기 화면 경로를 결정합니다.
-    func checkInitialScreen(coordinator: BabyMoaCoordinator) async {
-        // 1. 사용자 로그인 상태 확인
-        guard UserToken.accessToken != "" else {
-            // 로그인 되어 있지 않으면 시작 화면으로 이동
-            coordinator.push(path: .startBabyMoa)
-            isReady = true
-            return
-        }
-        
-        // 2. 등록된 아기 목록 확인
-        let result = await babyMoaService.getGetBabyList()
-        switch result {
-        case .success(let response):
-            if let babyList = response.data, !babyList.isEmpty {
-                // 아기 목록이 있으면 메인 탭 화면으로 이동
-                coordinator.push(path: .mainTab)
-            } else {
-                // 아기 목록이 없으면 아기 추가 화면으로 이동
-                coordinator.push(path: .addBaby)
-            }
-        case .failure:
-            // API 요청 실패 시에도 아기 추가 화면으로 이동 (오류 처리)
-            coordinator.push(path: .addBaby)
-        }
-        
-        // 3. 모든 확인 절차가 끝나면 isReady를 true로 설정하여 화면을 표시
-        isReady = true
-    }
+    init() {}
 }

--- a/Projects/BabyMoa/babyMoa/Manager/AppState.swift
+++ b/Projects/BabyMoa/babyMoa/Manager/AppState.swift
@@ -1,1 +1,41 @@
+//
+//  AppState.swift
+//  babyMoa
+//
+//  Created by Baba on 11/21/25.
+//
+//  앱의 최상위 상태를 관리하는 중앙 저장소 역할을 합니다.
+//  UI는 이 상태의 변화를 감지하여 화면을 업데이트합니다.
+//
 
+import Foundation
+import Combine
+
+/// 앱의 현재 세션 상태를 나타냅니다.
+enum SessionState {
+    /// 로그인되지 않은 상태. 온보딩/로그인 플로우를 보여줍니다.
+    case signedOut
+    
+    /// 로그인된 상태. 메인 앱 컨텐츠를 보여줍니다.
+    case signedIn
+}
+
+/// 앱의 전역 상태를 관리하는 ObservableObject 클래스입니다.
+/// 이 클래스는 싱글톤으로 사용되어 앱의 어떤 곳에서든 동일한 인스턴스에 접근할 수 있습니다.
+final class AppState: ObservableObject {
+    /// AppState의 공유 인스턴스.
+    static let shared = AppState()
+    
+    /// 현재 세션 상태를 Published 프로퍼티로 선언하여, SwiftUI 뷰가 이 값의 변경을 감지하고 자동으로 UI를 업데이트할 수 있도록 합니다.
+    @Published var sessionState: SessionState
+    
+    private init() {
+        // 앱 시작 시, 토큰 존재 여부에 따라 초기 세션 상태를 결정합니다.
+        // 토큰이 있으면 signedIn, 없으면 signedOut 상태로 시작합니다.
+        if TokenManager.shared.loadAccessToken() != nil {
+            self.sessionState = .signedIn
+        } else {
+            self.sessionState = .signedOut
+        }
+    }
+}

--- a/Projects/BabyMoa/babyMoa/Manager/SessionManager.swift
+++ b/Projects/BabyMoa/babyMoa/Manager/SessionManager.swift
@@ -4,5 +4,28 @@
 //
 //  Created by Baba on 10/20/25.
 //
+//  로그인, 로그아웃 등 세션과 관련된 전역 기능을 관리합니다.
+//
 
 import Foundation
+import SwiftUI
+
+final class SessionManager {
+    
+    /// 앱에서 로그아웃 또는 세션 종료가 필요할 때 호출하는 중앙 함수입니다.
+    /// 모든 로컬 데이터와 캐시를 정리하고, 앱의 상태를 '로그아웃'으로 변경하여
+    /// UI가 자동으로 로그인 화면으로 전환되도록 합니다.
+    @MainActor
+    static func signOut() {
+        print("ℹ️ [SessionManager] Signing out and clearing all session data.")
+        
+        // 1. 기기에 저장된 모든 토큰 정보 삭제
+        TokenManager.shared.clearAllTokens()
+        
+        // 2. 메모리에 캐싱된 마일스톤 데이터 삭제
+        MilestoneRepository.shared.clearCache()
+        
+        // 3. 전역 앱 상태를 '로그아웃'으로 변경하여 UI가 반응하도록 함
+        AppState.shared.sessionState = .signedOut
+    }
+}

--- a/Projects/BabyMoa/babyMoa/Network/BabyMoaEndpoint.swift
+++ b/Projects/BabyMoa/babyMoa/Network/BabyMoaEndpoint.swift
@@ -102,6 +102,9 @@ enum BabyMoaEndpoint: Endpoint {
     case deleteBaby(babyId: Int)
     case deleteHeight(babyId: Int, date: String)
     case deleteWeight(babyId: Int, date: String)
+    
+    // 계정 탈퇴를 위해 요청한다.
+    case deleteAccount
 }
 
 extension BabyMoaEndpoint {
@@ -156,6 +159,8 @@ extension BabyMoaEndpoint {
             return "/api/growth/delete_height"
         case .deleteWeight:
             return "/api/growth/delete_weight"
+        case .deleteAccount:
+            return "/api/auth/delete"
         }
     }
 
@@ -169,7 +174,7 @@ extension BabyMoaEndpoint {
         case .getGrowthData, .getBabyList, .getWeights, .getHeights, .getBaby, .getJourniesAtMonth, .getBabyMilestones, .getBabyInviteCode:
             return .get
         
-        case .deleteBabyMilestone, .deleteBaby, .deleteHeight, .deleteWeight:
+        case .deleteBabyMilestone, .deleteBaby, .deleteHeight, .deleteWeight, .deleteAccount:
             return .delete
             
         case .updateBaby:
@@ -189,7 +194,7 @@ extension BabyMoaEndpoint {
             .getGrowthData, .setTeethStatus, .getBabyList, .setWeight,
             .setHeight, .getWeights, .getHeights, .addJourney,
             .setBabyMilestone, .getBaby, .getJourniesAtMonth,
-            .getBabyMilestones, .deleteBabyMilestone, .getBabyInviteCode, .deleteBaby, .updateBaby, .deleteHeight, .deleteWeight:
+            .getBabyMilestones, .deleteBabyMilestone, .getBabyInviteCode, .deleteBaby, .updateBaby, .deleteHeight, .deleteWeight, .deleteAccount:
             return [
                 "accept": "*/*",
                 "Content-Type": "application/json",

--- a/Projects/BabyMoa/babyMoa/Repository/MilestoneRepository.swift
+++ b/Projects/BabyMoa/babyMoa/Repository/MilestoneRepository.swift
@@ -4,9 +4,9 @@
 //
 //  Created by Baba on 11/20/25.
 //
-//  This repository acts as a Single Source of Truth for milestone data.
-//  It fetches data from the network and caches it in memory to prevent
-//  redundant fetch operations across different ViewModels.
+//  이 리포지토리는 마일스톤 데이터에 대한 단일 진실 공급원(Single Source of Truth) 역할을 합니다.
+//  네트워크에서 데이터를 가져와 메모리에 캐싱함으로써,
+//  서로 다른 ViewModel에서 중복된 요청이 발생하는 것을 방지합니다.
 //
 
 import SwiftUI
@@ -19,11 +19,11 @@ final class MilestoneRepository {
     
     private init() {}
     
-    /// Fetches all milestones for a given baby ID.
-    /// It returns in-memory cached data if available for the same baby,
-    /// otherwise, it fetches from the network.
+    /// 주어진 아기 ID에 대한 모든 마일스톤을 가져옵니다.
+    /// 동일한 아기에 대한 메모리 캐시 데이터가 있으면 반환하고,
+    /// 그렇지 않으면 네트워크에서 가져옵니다.
     func fetchAllMilestones(babyId: Int) async -> [[GrowthMilestone]] {
-        // 1. Return cached data if it's for the same baby and not empty.
+        // 1. 동일한 아기에 대한 캐시된 데이터가 있고 비어 있지 않다면 캐시된 데이터를 반환합니다.
         if let cachedBabyId = self.cachedBabyId, cachedBabyId == babyId, !allMilestones.isEmpty {
             print("✅ [Repository] Returning cached milestones for babyId: \(babyId)")
             return allMilestones
@@ -31,44 +31,45 @@ final class MilestoneRepository {
         
         print("🟡 [Repository] No cached data. Fetching from server for babyId: \(babyId)")
         
-        // 2. Fetch from the network.
+        // 2. 네트워크에서 데이터를 가져옵니다.
         let result = await BabyMoaService.shared.getGetBabyMilestones(babyId: babyId)
         
         switch result {
         case .success(let success):
             guard let milestonesData = success.data else {
-                // In case of success with no data, clear cache and return default.
+                // 데이터가 없는 성공 응답인 경우, 캐시를 비우고 기본(mock) 데이터를 반환합니다.
                 clearCache()
                 return GrowthMilestone.mockData
             }
             
             var updatedMilestones = GrowthMilestone.mockData
             
-            // 3. Process the data, including fetching images concurrently.
-            // Using a TaskGroup is more performant for downloading multiple images.
+            // 3. 데이터를 처리합니다 (이미지 동시 다운로드 포함).
+            // 여러 이미지를 다운로드할 때는 TaskGroup을 사용하는 것이 성능상 더 효율적입니다.
             await withTaskGroup(of: (row: Int, col: Int, image: UIImage?).self) { group in
                 for milestone in milestonesData {
+                    // milestoneName 포맷(예: "milestone_0_1") 파싱
                     let row = Int(milestone.milestoneName.split(separator: "_")[1])!
                     let col = Int(milestone.milestoneName.split(separator: "_")[2])!
                     
-                    // Update non-image data immediately.
+                    // 이미지가 아닌 데이터(날짜, 설명 등)를 즉시 업데이트합니다.
                     if updatedMilestones.indices.contains(row) && updatedMilestones[row].indices.contains(col) {
                         updatedMilestones[row][col].completedDate = DateFormatter.yyyyDashMMDashdd.date(from: milestone.date)
                         updatedMilestones[row][col].description = milestone.memo
                         updatedMilestones[row][col].isCompleted = true
                     }
                     
-                    // Add a task to the group to download the image if a URL exists.
+                    // URL이 존재하면 이미지를 다운로드할 작업을 그룹에 추가합니다.
                     if let imageUrl = milestone.imageUrl, !imageUrl.isEmpty {
                         group.addTask {
-                            // This now uses our image caching system automatically.
+                            // ImageManager의 캐싱 시스템을 자동으로 사용합니다.
                             let image = await ImageManager.shared.downloadImage(from: imageUrl)
                             return (row, col, image)
                         }
                     }
                 }
                 
-                // Collect the results of the image download tasks as they complete.
+                // 이미지 다운로드 작업이 완료되는 대로 결과를 수집하여 업데이트합니다.
                 for await result in group {
                     if updatedMilestones.indices.contains(result.row) && updatedMilestones[result.row].indices.contains(result.col) {
                         updatedMilestones[result.row][result.col].image = result.image
@@ -76,7 +77,7 @@ final class MilestoneRepository {
                 }
             }
             
-            // 4. Cache the newly fetched and processed data.
+            // 4. 새로 가져오고 처리된 데이터를 캐시합니다.
             self.allMilestones = updatedMilestones
             self.cachedBabyId = babyId
             
@@ -84,15 +85,14 @@ final class MilestoneRepository {
             
         case .failure(let error):
             print("🔴 [Repository] Failed to fetch milestones: \(error)")
-            // On failure, clear cache and return default data to avoid showing stale data.
+            // 실패 시, 오래된 데이터를 보여주지 않기 위해 캐시를 비우고 기본 데이터를 반환합니다.
             clearCache()
             return GrowthMilestone.mockData
         }
     }
     
-    /// Invalidates the in-memory cache.
-    /// This should be called when data changes (e.g., a milestone is updated)
-    /// or when the user context changes (e.g., switching babies, logging out).
+    /// 메모리 캐시를 무효화합니다.
+    /// 데이터가 변경되거나(예: 마일스톤 업데이트), 사용자 컨텍스트가 변경될 때(예: 아기 변경, 로그아웃) 호출해야 합니다.
     func clearCache() {
         print("ℹ️ [Repository] Clearing milestone cache.")
         cachedBabyId = nil

--- a/Projects/BabyMoa/babyMoa/Utilities/ImageCacheManager.swift
+++ b/Projects/BabyMoa/babyMoa/Utilities/ImageCacheManager.swift
@@ -6,24 +6,24 @@
 //
 //
 
-import UIKit
+import SwiftUI
 import Foundation
 
-// MARK: - ImageCacheManager
+// MARK: - 이미지 캐시 매니저
 final class ImageCacheManager {
     static let shared = ImageCacheManager()
 
-    // MARK: - Properties
+    // MARK: - 속성
     private let memoryCache = NSCache<NSString, UIImage>()
     private let fileManager = FileManager.default
     private let diskCacheDirectoryName = "ImageCache" // 디스크 캐시를 저장할 디렉토리 이름
     
-    // MARK: - Initialization
+    // MARK: - 초기화
     private init() {
         createDiskCacheDirectory()
     }
 
-    // MARK: - Disk Cache Directory Management
+    // MARK: - 디스크 캐시 디렉토리 관리
     // 디스크 캐시 디렉토리 생성
     private func createDiskCacheDirectory() {
         guard let cacheDirectory = diskCacheURL else { return }
@@ -41,7 +41,7 @@ final class ImageCacheManager {
         return fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first?.appendingPathComponent(diskCacheDirectoryName)
     }
 
-    // MARK: - Key Generation for Disk Cache
+    // MARK: - 디스크 캐시용 키 생성
     // URL 문자열을 기반으로 디스크 파일명에 사용할 안전한 키 생성
     private func cacheKey(for urlString: String) -> String {
         // URL 문자열을 Percent-Encoding하여 파일명으로 안전하게 사용
@@ -51,7 +51,7 @@ final class ImageCacheManager {
             return encodedString
         }
         // 인코딩 실패 시 UUID를 사용하여 고유한 이름 생성
-        return UUID().uuidString 
+        return UUID().uuidString
     }
     
     // 디스크 캐시에 저장될 파일의 전체 URL 경로
@@ -59,7 +59,7 @@ final class ImageCacheManager {
         return diskCacheURL?.appendingPathComponent(key)
     }
 
-    // MARK: - Public Methods
+    // MARK: - 공개 메서드 (Public Methods)
     
     /// 주어진 URL 문자열에 해당하는 이미지를 캐시에서 가져옵니다.
     /// (메모리 캐시 먼저 확인 후, 없으면 디스크 캐시 확인)
@@ -100,7 +100,7 @@ final class ImageCacheManager {
 
         // 2. 디스크 캐시에 저장
         // 원본 imageData가 있으면 사용하고, 없으면 UIImage를 JPEG 데이터로 변환하여 저장
-        guard let dataToSave = imageData ?? image.jpegData(compressionQuality: 0.8), 
+        guard let dataToSave = imageData ?? image.jpegData(compressionQuality: 0.8),
               let fileURL = getDiskCacheFileURL(forKey: cacheKey(for: urlString)) else { return }
         
         do {

--- a/Projects/BabyMoa/babyMoa/Views/AddBaby/ViewModels/AddBabyViewModel.swift
+++ b/Projects/BabyMoa/babyMoa/Views/AddBaby/ViewModels/AddBabyViewModel.swift
@@ -185,6 +185,7 @@ class AddBabyViewModel: ObservableObject {
                 switch result {
                 case .success:
                     print("✅ [UPDATE] 아기 정보 수정 성공")
+                    BabyRepository.shared.clearCache()
                     coordinator.pop()
                 case .failure(let error):
                     print("❌ [UPDATE] 아기 정보 수정 실패: \(error.localizedDescription)")
@@ -243,6 +244,7 @@ class AddBabyViewModel: ObservableObject {
                 switch result {
                 case .success(let response):
                     print("✅ [CREATE] 아기 등록 성공: \(response)")
+                    BabyRepository.shared.clearCache()
                     coordinator.paths.removeAll()
                     
                 case .failure(let error):
@@ -275,6 +277,7 @@ class AddBabyViewModel: ObservableObject {
                 if SelectedBabyState.shared.baby?.babyId == babyId {
                     SelectedBabyState.shared.baby = nil
                 }
+                BabyRepository.shared.clearCache()
                 coordinator.popToRoot() // Go back to the root view after deletion
             case .failure(let error):
                 print("❌ [DELETE] 아기 삭제 실패: \(error.localizedDescription)")

--- a/Projects/BabyMoa/babyMoa/Views/Auth/Account/AccountDeleteConfirmView.swift
+++ b/Projects/BabyMoa/babyMoa/Views/Auth/Account/AccountDeleteConfirmView.swift
@@ -1,8 +1,194 @@
 //
 //  AccountDeleteConfirmView.swift
-//  BabyMoa
+//  babyMoa
 //
 //  Created by Baba on 11/21/25.
 //
 
-import Foundation
+import SwiftUI
+
+struct AccountDeleteConfirmView: View {
+
+    let coordinator: BabyMoaCoordinator
+
+    @State private var isAgreed: Bool = false
+    @State private var isLoading: Bool = false
+    
+    @State private var showErrorAlert: Bool = false
+    @State private var alertMessage: String = ""
+
+    var body: some View {
+        ZStack {
+            Color.background
+
+            VStack(spacing: 0) {
+                // MARK: - Custom Navigation Bar
+                CustomNavigationBar(
+                    title: "탈퇴하기",
+                    leading: {
+                        Button {
+                            coordinator.pop()
+                        } label: {
+                            Image(systemName: "chevron.left")
+                        }
+                    }
+                )
+                // MARK: - Content
+                ScrollView {
+                    VStack(spacing: 20) {
+
+                        // 상단 "탈퇴 전 확인" 타이틀
+                        Text("탈퇴 전 확인")
+                            .font(.system(size: 26, weight: .medium))
+                            .foregroundStyle(.font)
+                            .padding(.top, 28)
+
+                        // 안내 박스
+                        VStack(alignment: .leading, spacing: 10) {
+                            HStack(alignment: .top, spacing: 8) {
+                                Image(systemName: "checkmark")
+                                    .font(.system(size: 14, weight: .bold))
+                                    .foregroundStyle(Color.brand50)
+
+                                Text("다른 양육자가 없는 아기의 정보가 삭제돼요.")
+                                    .font(.system(size: 14, weight: .medium))
+                                    .foregroundStyle(.font)
+                            }
+
+                            HStack(alignment: .top, spacing: 8) {
+                                Image(systemName: "checkmark")
+                                    .font(.system(size: 14, weight: .bold))
+                                    .foregroundStyle(Color.brand50)
+
+                                Text("모든 삭제된 데이터는 복구할 수 없어요.")
+                                    .font(.system(size: 14, weight: .medium))
+                                    .foregroundStyle(.font)
+                            }
+                        }
+                        .padding(20)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(Color.gray90)
+                        )
+                    }
+                }
+                .scrollIndicators(.hidden)
+                
+                
+                if isAgreed {
+                    ZStack{
+                        
+                        Text("홍길동님을 다시 만날 수 없어 아쉬워요. 아이의 어린 시절을 붙잡을 수 없듯 홍길동님을 추억할게요.")
+                            .font(.system(size: 18))
+                            .lineSpacing(3)
+                            .padding(15)
+                            .foregroundStyle(Color.font)
+                            .multilineTextAlignment(.leading)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(
+                                UnevenRoundedRectangle(
+                                    cornerRadii: .init(
+                                        topLeading: 12,
+                                        bottomLeading: 12,
+                                        bottomTrailing: 0,
+                                        topTrailing: 12
+                                    )
+                                )
+                                .stroke(Color.gray90, lineWidth: 1)
+                            )
+                            .overlay {
+                                Image(.accountBird)
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(width: 92, height: 138)
+                                    .offset(x: 120, y: 30) //
+                            }
+                     
+                       
+
+                    }
+                    .padding(.bottom, 56)
+                }
+                
+                // 체크박스 영역
+                Button {
+                    isAgreed.toggle()
+                } label: {
+                    HStack(alignment: .center, spacing: 4) {
+                        Image(
+                            systemName: isAgreed
+                            ? "checkmark.square.fill"
+                            : "square"
+                        )
+                        .font(.system(size: 20))
+                        .foregroundStyle(
+                            isAgreed ? Color.brand50 : Color.gray70
+                        )
+
+                        Text("안내사항을 모두 확인했으며, 동의합니다.")
+                            .font(.system(size: 18, weight: .medium))
+                            .foregroundStyle(.font)
+
+                        Spacer()
+                    }
+                }
+                .padding(.bottom, 20)
+
+                // MARK: - Bottom Button
+                Button {
+                    Task {
+                        await deleteAccount()
+                    }
+                } label: {
+                    Text("탈퇴하기")
+                }
+                .buttonStyle(isAgreed ? .defaultButton : .noneButton)
+                .disabled(!isAgreed || isLoading)
+                .padding(.bottom, 44)
+            }
+            .backgroundPadding(.horizontal)
+        }
+        .ignoresSafeArea()
+        .alert("알림", isPresented: $showErrorAlert) {
+            Button("확인") {}
+        } message: {
+            Text(alertMessage)
+        }
+    }
+
+    // MARK: - 탈퇴 처리
+    @MainActor
+    private func deleteAccount() async {
+        guard !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+
+        let result = await BabyMoaService.shared.deleteAccount()
+        
+        // `BabyMoaService`의 `refreshToken` 함수가 전역 인증 오류를 감지하고
+        // `SessionManager.signOut()`을 호출하므로, 여기서는 성공 케이스와
+        // 인증 오류 외의 일반적인 실패 케이스만 처리합니다.
+        switch result {
+        case .success:
+            // 계정 삭제 성공 시, 중앙 로그아웃 함수를 호출하여 모든 데이터를 정리하고 초기 화면으로 이동합니다.
+            SessionManager.signOut()
+            
+        case .failure(let error):
+            // 인증 오류가 아닌 다른 모든 오류에 대해 사용자에게 알림을 표시합니다.
+            // (인증 오류는 BabyMoaService에서 감지하여 자동으로 signOut을 호출합니다.)
+            if case .unauthorized = error {
+                // 이 케이스는 BabyMoaService의 refreshToken 로직에 의해 처리되므로
+                // 일반적으로 여기에 도달하지 않지만, 만약을 위해 비워둡니다.
+                // 전역 핸들러가 UI를 이미 리셋했을 것입니다.
+            } else {
+                alertMessage = "계정 탈퇴에 실패했습니다. 네트워크 연결을 확인하고 다시 시도해 주세요."
+                showErrorAlert = true
+            }
+        }
+    }
+}
+
+#Preview {
+    AccountDeleteConfirmView(coordinator: BabyMoaCoordinator())
+}

--- a/Projects/BabyMoa/babyMoa/Views/Auth/SignUp/SignUpViewModel.swift
+++ b/Projects/BabyMoa/babyMoa/Views/Auth/SignUp/SignUpViewModel.swift
@@ -59,11 +59,15 @@ final class SignUpViewModel {
                             return
                         }
                         let tokenResult = await resModel.toDomain()
+                        
+                        // 1. UserToken의 정적 변수에 토큰을 할당합니다.
+                        //    (@UserDefault 래퍼를 통해 UserDefaults에도 자동으로 저장됩니다.)
                         UserToken.accessToken = tokenResult.accessToken
                         UserToken.refreshToken = tokenResult.refreshToken
+                        
                         await MainActor.run {
-                            // 네비게이션 스택을 리셋하여 RootView에서 초기 경로를 다시 결정하도록 합니다.
-                            coordinator.paths.removeAll()
+                            // 2. 앱의 전역 상태를 '로그인 됨'으로 변경하여 UI를 업데이트합니다.
+                            AppState.shared.sessionState = .signedIn
                         }
                     case .failure(let error):
                         print(error)

--- a/Projects/BabyMoa/babyMoa/Views/Baby/BabyMainView.swift
+++ b/Projects/BabyMoa/babyMoa/Views/Baby/BabyMainView.swift
@@ -34,11 +34,46 @@ struct BabyMainView: View {
                     coordinator.push(path: .addBaby)
                 }
                 
-                Button("로그아웃", action: {
-                    // TODO: 로그아웃 기능 구현
-                    viewModel.showSignOutAlert = true
-                })
-                .buttonStyle(.outlineThirdButton)
+               
+                
+                // 계정 타이틀
+                Text("계정")
+                    .font(.system(size: 14, weight: .medium))
+                    .padding(.leading, 4) // 타이틀에 약간의 여백을 주면 더 자연스럽습니다 (선택)
+
+                VStack(spacing: 0) {
+                    //MARK: - 1. 로그아웃 버튼
+                    Button(action: {
+                        viewModel.showSignOutAlert = true
+                    }, label: {
+                        Text("로그아웃")
+                            .font(.system(size: 14))
+                            .foregroundStyle(Color.font)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(16)
+                    })
+                    // 구분선
+                    Divider()
+                        .padding(.horizontal, 16) // 좌우 여백을 텍스트와 맞춤 (선택사항)
+                    //MARK: - 2. 탈퇴하기 버튼
+                    Button(action: {
+                        coordinator.push(path: .accountDeleteConfirmView)
+                    }, label: {
+                        HStack {
+                            Text("탈퇴하기")
+                                .font(.system(size: 14))
+                                .foregroundStyle(Color.font)
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .foregroundStyle(Color.font)
+                                .font(.system(size: 14))
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(16)
+                    })
+                }
+                .background(Color.white)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
                 
                 Spacer()
             }
@@ -46,7 +81,7 @@ struct BabyMainView: View {
         .scrollIndicators(.hidden)
         .backgroundPadding(.horizontal)
         .background(Color.background)
-
+        
         
         .alert("로그아웃할까요?", isPresented: $viewModel.showSignOutAlert, actions: {
             Button("로그아웃", role: .destructive) {

--- a/Projects/BabyMoa/babyMoa/Views/Baby/ViewModels/BabyMainViewModel.swift
+++ b/Projects/BabyMoa/babyMoa/Views/Baby/ViewModels/BabyMainViewModel.swift
@@ -37,17 +37,8 @@ class BabyMainViewModel: ObservableObject {
     }
     
     func signOut() {
-        // 1. Clear tokens
-        UserToken.accessToken = ""
-        UserToken.refreshToken = ""
-        
-        // 2. Clear selected baby from UserDefaults
-        SelectedBaby.babyId = nil
-        
-        // 3. Clear selected baby from in-memory state
-        SelectedBabyState.shared.baby = nil
-        
-        // 4. Reset navigation stack to trigger root view change
-        coordinator.paths = []
+        // 중앙 세션 관리자를 통해 안전하게 로그아웃을 처리합니다.
+        // 이 함수 하나로 토큰 삭제, 캐시 클리어, 화면 상태 변경이 모두 이루어집니다.
+        SessionManager.signOut()
     }
 }

--- a/Projects/BabyMoa/babyMoa/Views/Components/CachedAsyncImage.swift
+++ b/Projects/BabyMoa/babyMoa/Views/Components/CachedAsyncImage.swift
@@ -4,8 +4,8 @@
 //
 //  Created by Baba on 11/20/25.
 //
-//  This view mimics SwiftUI's AsyncImage, but uses a custom ImageManager
-//  to leverage a shared, persistent cache.
+//  이 뷰는 SwiftUI의 AsyncImage와 유사하게 동작하지만,
+//  공유된 영구 캐시(Memory/Disk)를 활용하기 위해 커스텀 ImageManager를 사용합니다.
 //
 
 import SwiftUI
@@ -18,7 +18,7 @@ struct CachedAsyncImage<Content: View>: View {
     let transaction: Transaction
     let content: (AsyncImagePhase) -> Content
     
-    // Define the error type at the struct level, not inside the function.
+    // 함수 내부가 아닌 구조체 레벨에서 에러 타입을 정의합니다.
     private struct ImageLoadError: Error {}
     
     init(
@@ -44,15 +44,15 @@ struct CachedAsyncImage<Content: View>: View {
             return
         }
         
-        // Set phase to empty before starting.
+        // 시작하기 전에 단계를 empty로 설정합니다.
         if !Task.isCancelled {
             withAnimation(transaction.animation) {
                 self.phase = .empty
             }
         }
         
-        // Use our custom image manager to fetch the image.
-        // This will hit the memory/disk cache or download from the network.
+        // 커스텀 이미지 매니저를 사용하여 이미지를 가져옵니다.
+        // 이 과정에서 메모리/디스크 캐시를 확인하거나 네트워크에서 다운로드합니다.
         if let uiImage = await ImageManager.shared.downloadImage(from: url) {
             if !Task.isCancelled {
                 let image = Image(uiImage: uiImage)
@@ -62,7 +62,7 @@ struct CachedAsyncImage<Content: View>: View {
             }
         } else {
             if !Task.isCancelled {
-                // Now we can create an instance of the error.
+                // 실패 시 에러 인스턴스를 생성하여 단계를 업데이트합니다.
                 withAnimation(transaction.animation) {
                     self.phase = .failure(ImageLoadError())
                 }
@@ -72,11 +72,11 @@ struct CachedAsyncImage<Content: View>: View {
 }
 
 #Preview {
-    // Example usage:
+    // 사용 예시:
     let sampleUrl = "https://yesagile-s3-bucket.s3.amazonaws.com/avatars/2025/11/08/38d90084-0fcd-4f34-bc25-471dc2d2f704.jpg"
     
     return VStack {
-        Text("CachedAsyncImage Preview")
+        Text("CachedAsyncImage 미리보기")
             .font(.headline)
         
         CachedAsyncImage(urlString: sampleUrl) { phase in

--- a/Projects/BabyMoa/babyMoa/Views/MainTab/MainTabView.swift
+++ b/Projects/BabyMoa/babyMoa/Views/MainTab/MainTabView.swift
@@ -77,6 +77,13 @@ struct MainTabView: View {
                 .presentationDragIndicator(.visible)
             }
         }
+        .onAppear {
+            // 이 뷰가 나타날 때마다 아기 목록을 가져옵니다.
+            // BabyRepository의 캐싱 덕분에, 변경사항이 없을 경우 네트워크 요청 없이 빠르게 로드됩니다.
+            Task {
+                await viewModel.fetchBabies()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
- AppState 중심 인증 흐름과 화면 전환 구조(AuthenticatedRootView) 문서화
- BabyMoaCoordinator 기반 Navigation 흐름 및 역할 정리
- Repository 패턴(BabyRepository, MilestoneRepository) 도입 의도와 캐싱 구조 상세화
- BabyMoaService 네트워크 계층 및 전역 오류 처리(세션 만료 → 중앙 로그아웃) 설명 추가
- SessionManager의 역할과 signOut() 처리 플로우 문서화
- 2단계 이미지 캐싱 시스템(ImageManager & ImageCacheManager) 구조 설명
- ‘아기 추가(AddBaby)’ 플로우 전체 단계 흐름 상세 문서 작성
  - 서버 등록 이후 캐시 무효화(clearCache) 처리
  - 화면 스택 초기화(coordinator.paths.removeAll)
  - RootView 재로딩 및 최신 리스트 fetch 과정 설명
- 전체 데이터 흐름 도식화 및 팀원 이해용 Markdown 문서(Notion 공유용) 작성
