### PR TITLE
feat(image-caching): AsyncImage를 CachedAsyncImage로 교체하여 이미지 캐싱 성능 개선

### DIFF
--- a/Projects/BabyMoa/babyMoa/Views/Baby/Subview/MainTopNavigtaionView.swift
+++ b/Projects/BabyMoa/babyMoa/Views/Baby/Subview/MainTopNavigtaionView.swift
@@ -64,8 +64,8 @@ struct MainTopNavigtaionView: View {
     
     @ViewBuilder
     private var profileImageView: some View {
-        if let imageUrlString = babyImage, let url = URL(string: imageUrlString) {
-            AsyncImage(url: url) { phase in
+        if let imageUrlString = babyImage {
+            CachedAsyncImage(urlString: imageUrlString) { phase in
                 switch phase {
                 case .empty:
                     ProgressView()

--- a/Projects/BabyMoa/babyMoa/Views/Guardian/GuardianCodeView.swift
+++ b/Projects/BabyMoa/babyMoa/Views/Guardian/GuardianCodeView.swift
@@ -30,8 +30,8 @@ struct GuardianCodeView: View {
                 ScrollView {
                     VStack(spacing: 20) {
                         // 아기 프로필 이미지 표시
-                        if let imageUrlString = viewModel.selectedBabyImageURL, let url = URL(string: imageUrlString) {
-                            AsyncImage(url: url) { phase in
+                        if let imageUrlString = viewModel.selectedBabyImageURL {
+                            CachedAsyncImage(urlString: imageUrlString) { phase in
                                 switch phase {
                                 case .empty:
                                     ProgressView()

--- a/Projects/BabyMoa/babyMoa/Views/Guardian/GuardianInvitationView.swift
+++ b/Projects/BabyMoa/babyMoa/Views/Guardian/GuardianInvitationView.swift
@@ -34,8 +34,8 @@ struct GuardianInvitationView: View {
                 ScrollView {
                     VStack(spacing: 20){
                         // 아기 프로필 이미지 표시
-                        if let imageUrlString = viewModel.selectedBabyImageURL, let url = URL(string: imageUrlString) {
-                            AsyncImage(url: url) { phase in
+                        if let imageUrlString = viewModel.selectedBabyImageURL {
+                            CachedAsyncImage(urlString: imageUrlString) { phase in
                                 switch phase {
                                 case .empty:
                                     ProgressView()


### PR DESCRIPTION
✨ PR: SwiftUI AsyncImage → 커스텀 CachedAsyncImage 교체 및 2단계 캐싱 적용

📌 관련 파일 변경
	•	babyMoa/Views/Baby/Subview/MainTopNavigtaionView.swift
	•	babyMoa/Views/Guardian/GuardianCodeView.swift
	•	babyMoa/Views/Guardian/GuardianInvitationView.swift

⸻

✨ What’s this PR?

SwiftUI 기본 AsyncImage를 커스텀 CachedAsyncImage 컴포넌트로 교체했습니다.
이를 통해 ImageManager 기반의 메모리/디스크 2단계 캐싱 구조가 적용되며,
이미지 로딩 속도 개선 및 네트워크 요청 수 감소 효과를 얻습니다.

⸻

🧶 주요 변경 내용 (Summary)
	•	기존 AsyncImage → CachedAsyncImage 로 모두 교체
	•	ImageManager의 2단계 캐싱 로직(메모리 + 디스크) UI 레이어에 적용
	•	이미지 로딩 성능 향상 (스크롤 시 부드럽고 깜빡임 감소)
	•	불필요한 네트워크 요청 감소


⸻