### PR TITLE
Feature/#69 사진 라이브러리 접근 권한 허용 로직 구현 및 AddBabyStatusView 적용

### DIFF
--- a/Projects/BabyMoa/babyMoa/Manager/PermissionManager.swift
+++ b/Projects/BabyMoa/babyMoa/Manager/PermissionManager.swift
@@ -1,0 +1,44 @@
+//
+//  PermissionManager.swift
+//  BabyMoa
+//
+//  Created by 한건희 on 11/23/25.
+//
+
+import PhotosUI
+import Photos
+
+final class PermissionManager {
+    static let shared = PermissionManager()
+    
+    private init() { }
+    
+    /// 사진 라이브러리 접근 권한 체크
+    /// - Parameters:
+    ///   - authorized: 권한이 있을 때 실행할 클로저
+    ///   - denied: 권한이 없을 때 실행할 클로저
+    func checkPhotoLibraryPermission(
+        authorized: @escaping () -> Void,
+        denied: @escaping () -> Void
+    ) {
+        let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        
+        switch status {
+        case .authorized, .limited:
+            authorized()
+        case .notDetermined:
+            PHPhotoLibrary.requestAuthorization(for: .readWrite) { newStatus in
+                DispatchQueue.main.async {
+                    switch newStatus {
+                    case .authorized, .limited:
+                        authorized()
+                    default:
+                        denied()
+                    }
+                }
+            }
+        default:
+            denied()
+        }
+    }
+}

--- a/Projects/BabyMoa/babyMoa/Views/AddBaby/AddBabyStatusView.swift
+++ b/Projects/BabyMoa/babyMoa/Views/AddBaby/AddBabyStatusView.swift
@@ -74,7 +74,7 @@ struct AddBabyStatusView: View {
                             }
                         }
                         .onTapGesture {
-                            viewModel.showLibrary = true
+                            viewModel.showPhotoLibrary()
                         }
                         
                         // 이름 / 태명 / 성별
@@ -193,6 +193,9 @@ struct AddBabyStatusView: View {
         } message: {
             Text("나에게만 아기 정보가 삭제돼요.")
         }
+        .overlay(
+            PermissionModal(isPresented: $viewModel.showPermissionModal)
+        )
     }
 }
 

--- a/Projects/BabyMoa/babyMoa/Views/AddBaby/AddBabyView.swift
+++ b/Projects/BabyMoa/babyMoa/Views/AddBaby/AddBabyView.swift
@@ -10,7 +10,6 @@
 import SwiftUI
 
 struct AddBabyView: View {
-    
     @StateObject private var viewModel: AddBabyViewModel
     
     init(coordinator: BabyMoaCoordinator) {

--- a/Projects/BabyMoa/babyMoa/Views/AddBaby/ViewModels/AddBabyViewModel.swift
+++ b/Projects/BabyMoa/babyMoa/Views/AddBaby/ViewModels/AddBabyViewModel.swift
@@ -30,6 +30,7 @@ class AddBabyViewModel: ObservableObject {
     @Published var showRelationshipPicker: Bool = false
     @Published var showDeleteConfirmation: Bool = false
     @Published var inviteCodeAccessComplete: Bool = false
+    @Published var showPermissionModal: Bool = false
 
     // MARK: - Photo Picker
     @Published var showImageOptions: Bool = false
@@ -355,5 +356,16 @@ class AddBabyViewModel: ObservableObject {
         } catch {
             print("❌ 이미지 로드 실패: \(error.localizedDescription)")
         }
+    }
+    
+    func showPhotoLibrary() {
+        PermissionManager.shared.checkPhotoLibraryPermission(
+            authorized: {
+                self.showLibrary = true
+            },
+            denied: {
+                self.showPermissionModal = true
+            }
+        )
     }
 }

--- a/Projects/BabyMoa/babyMoa/Views/Components/PermissionModal.swift
+++ b/Projects/BabyMoa/babyMoa/Views/Components/PermissionModal.swift
@@ -1,0 +1,107 @@
+//
+//  PermissionModal.swift
+//  BabyMoa
+//
+//  Created by 한건희 on 11/23/25.
+//
+
+import SwiftUI
+
+struct PermissionModal: View {
+    @Binding var isPresented: Bool
+
+    @State private var animateIn: Bool = false   // 등장 애니메이션
+    @State private var animateOut: Bool = false  // 퇴장 애니메이션
+
+    var body: some View {
+        if isPresented || animateOut {
+            ZStack {
+                // 배경 dim
+                Color.black.opacity(animateIn ? 0.35 : 0)
+                    .ignoresSafeArea()
+                    .animation(.easeInOut(duration: 0.25), value: animateIn)
+                    .onTapGesture {
+                        close()
+                    }
+
+                // 모달 카드
+                VStack(spacing: 20) {
+                    Text("사진 라이브러리 권한허용을 위해\n설정으로 이동하세요.")
+                        .font(.body)
+                        .multilineTextAlignment(.center)
+                        .lineSpacing(8)
+                        .padding(.horizontal)
+                        .padding(.top, 15)
+                        .padding(.bottom, 15)
+                        .frame(height: 100)
+                        
+                    HStack(spacing: 15) {
+                        Button(action: {
+                            close()
+                        }) {
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(.white)
+                                .frame(maxWidth: 100, maxHeight: 45)
+                                .overlay(
+                                    Text("취소")
+                                        .foregroundStyle(.accent)
+                                )
+                        }
+                        .buttonStyle(.plain)
+                        
+                        Button(action: {
+                            openSettings()
+                        }) {
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(.accent)
+                                .frame(maxWidth: 100, maxHeight: 45)
+                                .overlay(
+                                    Text("이동")
+                                        .foregroundStyle(.white)
+                                )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .padding(.horizontal, 20)
+                }
+                .padding(.vertical, 10)
+                .frame(maxWidth: 300)
+                .background(
+                    RoundedRectangle(cornerRadius: 20, style: .continuous)
+                        .fill(Color(.systemBackground))
+                )
+                .scaleEffect(animateIn ? 1.0 : 0.85)
+                .opacity(animateIn ? 1.0 : 0.0)
+                .offset(y: animateIn ? 0 : 60)
+                .shadow(color: .black.opacity(0.1), radius: 15)
+                .animation(.spring(response: 0.35, dampingFraction: 0.8), value: animateIn)
+            }
+            .onAppear {
+                animateIn = true
+            }
+        }
+    }
+
+    // MARK: - Close handling
+    private func close() {
+        animateIn = false
+        animateOut = true
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+            isPresented = false
+            animateOut = false
+        }
+    }
+
+    // MARK: - Open Settings
+    private func openSettings() {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(url)
+        }
+    }
+}
+
+#Preview {
+    @Previewable @State var isPresented = true
+    PermissionModal(isPresented: $isPresented)
+}

--- a/Projects/babyMoa/BabyMoa.xcodeproj/project.pbxproj
+++ b/Projects/babyMoa/BabyMoa.xcodeproj/project.pbxproj
@@ -191,7 +191,7 @@
 					};
 				};
 			};
-			buildConfigurationList = D4110B632EBBC61100B0C783 /* Build configuration list for PBXProject "babyMoa" */;
+			buildConfigurationList = D4110B632EBBC61100B0C783 /* Build configuration list for PBXProject "BabyMoa" */;
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -414,6 +414,7 @@
 				INFOPLIST_FILE = "BabyMoa-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = BabyMoA;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.lifestyle";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -453,6 +454,7 @@
 				INFOPLIST_FILE = "BabyMoa-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = BabyMoA;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.lifestyle";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -554,7 +556,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		D4110B632EBBC61100B0C783 /* Build configuration list for PBXProject "babyMoa" */ = {
+		D4110B632EBBC61100B0C783 /* Build configuration list for PBXProject "BabyMoa" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D4110B872EBBC61200B0C783 /* Debug */,


### PR DESCRIPTION
## ✨ What’s this PR?

- 사진 라이브러리 접근 권한 허용을 위한 PermissionManager 클래스 구현
- 첫 시스템 권한 모달 이후 권한 거부 시 설정창으로 이동 유도할 수 있는 PermissionModal 구현
- AddBabyStatusView 에서 아기 이미지 사진 선택 시 사진 라이브러리 접근 권한 있을 때만 가능하도록 모달 추가
- 앱 첫 실행 시 시스템 모달 뜨도록 함

### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #69

---

### 🧶 주요 변경 내용 (Summary)

- 사진 라이브러리 접근 권한 허용을 위한 PermissionManager 클래스 구현
- 첫 시스템 권한 모달 이후 권한 거부 시 설정창으로 이동 유도할 수 있는 PermissionModal 구현
- AddBabyStatusView 에서 아기 이미지 사진 선택 시 사진 라이브러리 접근 권한 있을 때만 가능하도록 모달 추가
- 앱 첫 실행 시 시스템 모달 뜨도록 함

---

### 📸 스크린샷

https://github.com/user-attachments/assets/4836202d-9820-401e-81f9-83aab67690fb

<img width="433" height="880" alt="image" src="https://github.com/user-attachments/assets/a4e523c8-cfa6-4183-bfd6-a8bbbe90d5c7" />
