### PR TITLE
hotfix: 앱 실행 시 사진 라이브러리 접근 권한 요청 로직 누락되어 추가

### DIFF
--- a/Projects/BabyMoa/babyMoa/App/BabyMoaRoot/BabyMoaRootView.swift
+++ b/Projects/BabyMoa/babyMoa/App/BabyMoaRoot/BabyMoaRootView.swift
@@ -122,5 +122,8 @@ struct BabyMoaRootView: View {
                 coordinator.paths.removeAll()
             }
         }
+        .onAppear {
+            PermissionManager.shared.checkPhotoLibraryPermission()
+        }
     }
 }

--- a/Projects/BabyMoa/babyMoa/Manager/PermissionManager.swift
+++ b/Projects/BabyMoa/babyMoa/Manager/PermissionManager.swift
@@ -18,8 +18,8 @@ final class PermissionManager {
     ///   - authorized: 권한이 있을 때 실행할 클로저
     ///   - denied: 권한이 없을 때 실행할 클로저
     func checkPhotoLibraryPermission(
-        authorized: @escaping () -> Void,
-        denied: @escaping () -> Void
+        authorized: @escaping () -> Void = {},
+        denied: @escaping () -> Void = {}
     ) {
         let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
         


### PR DESCRIPTION
## ✨ What’s this PR?
앱 실행 시 사진 라이브러리 접근 권한 요청 로직 누락되어 추가

### 📌 관련 이슈 (Related Issue)
- Closes #69

---

### 🧶 주요 변경 내용 (Summary)

- 앱 실행 시 사진 라이브러리 접근 권한 요청 로직 누락되어 추가
